### PR TITLE
Refactor multiple components: change imports of types to use 'import …

### DIFF
--- a/pages/articles.tsx
+++ b/pages/articles.tsx
@@ -7,7 +7,7 @@ import { useRouter } from 'next/router'
 import Layout from '../components/Layout'
 
 import { sanityClient, urlFor } from '../lib/sanityClient'
-import { Article } from '../typings'
+import type { Article } from '../typings'
 
 import { CalendarIcon } from '@heroicons/react/outline'
 import { ChevronDownIcon, ChevronUpIcon } from '@heroicons/react/outline'

--- a/pages/event/[slug].tsx
+++ b/pages/event/[slug].tsx
@@ -4,7 +4,7 @@ import { GetStaticProps } from 'next'
 
 import LayoutSlug from '../../components/LayoutSlug'
 
-import { Event } from '../../typings'
+import type { Event } from '../../typings'
 import PortableText from 'react-portable-text'
 import { sanityClient } from '../../lib/sanityClient'
 import {

--- a/pages/events.tsx
+++ b/pages/events.tsx
@@ -5,7 +5,7 @@ import Layout from '../components/Layout'
 
 import { CalendarIcon } from '@heroicons/react/outline'
 
-import { Event } from '../typings'
+import type { Event } from '../typings'
 import { sanityClient, urlFor } from '../lib/sanityClient'
 
 import DefaultImage from '../assets/default-image.png'

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,4 +1,4 @@
-import { Article, WeeklyReminder } from '../typings'
+import type { Article, WeeklyReminder } from '../typings'
 import { sanityClient, urlFor } from '../lib/sanityClient'
 
 import Donate from '../components/Donate'

--- a/pages/info-events.tsx
+++ b/pages/info-events.tsx
@@ -9,7 +9,7 @@ import Layout from '../components/Layout'
 import { CalendarIcon } from '@heroicons/react/outline'
 
 import { sanityClient, urlFor } from '../lib/sanityClient'
-import { Event, InfoNews } from '../typings'
+import type { Event, InfoNews } from '../typings'
 import {
   ChevronDownIcon,
   ChevronUpIcon,

--- a/pages/info-news.tsx
+++ b/pages/info-news.tsx
@@ -6,7 +6,7 @@ import Layout from '../components/Layout'
 import { CalendarIcon } from '@heroicons/react/outline'
 
 import { sanityClient, urlFor } from '../lib/sanityClient'
-import { InfoNews } from '../typings'
+import type { InfoNews } from '../typings'
 
 import DefaultImage from '../assets/default-image.png'
 

--- a/pages/info-news/[slug].tsx
+++ b/pages/info-news/[slug].tsx
@@ -3,7 +3,7 @@ import Link from 'next/link'
 
 import LayoutSlug from '../../components/LayoutSlug'
 
-import { InfoNews } from '../../typings'
+import type { InfoNews } from '../../typings'
 import PortableText from 'react-portable-text'
 import { sanityClient } from '../../lib/sanityClient'
 

--- a/pages/privacy.tsx
+++ b/pages/privacy.tsx
@@ -4,7 +4,7 @@ import { GetStaticProps } from 'next'
 
 import Layout from '../components/Layout'
 
-import { Privacy } from '../typings'
+import type { Privacy } from '../typings'
 import PortableText from 'react-portable-text'
 import { sanityClient } from '../lib/sanityClient'
 


### PR DESCRIPTION
…type' for improved TypeScript clarity across articles, events, info-events, info-news, privacy, and dynamic event pages.