### PR TITLE
Implement duration formatting in Updates and Articles components: Add…

### DIFF
--- a/components/Updates.tsx
+++ b/components/Updates.tsx
@@ -21,6 +21,19 @@ const Updates = ({ updates }: UpdatesProps) => {
     }
   }
 
+  const formatDuration = (duration: string) => {
+    // If duration is just a number (like "10"), convert to "10:00"
+    if (/^\d+$/.test(duration)) {
+      return `${duration}:00`
+    }
+    // If it's already in MM:SS format, return as is
+    if (/^\d+:\d{2}$/.test(duration)) {
+      return duration
+    }
+    // Default fallback
+    return duration
+  }
+
   if (!updates || updates.length === 0) {
     return null
   }
@@ -43,7 +56,7 @@ const Updates = ({ updates }: UpdatesProps) => {
             {update.title}
             <span className="font-sm ml-2 flex items-center text-xs md:text-base">
               {getIcon(update.type)}
-              {update.duration}
+              {formatDuration(update.duration)}
             </span>
           </li>
         ))}

--- a/pages/articles.tsx
+++ b/pages/articles.tsx
@@ -148,6 +148,19 @@ const Articles = ({ articles, updates }: Props) => {
                 }
               }
 
+              const formatDuration = (duration: string) => {
+                // If duration is just a number (like "10"), convert to "10:00"
+                if (/^\d+$/.test(duration)) {
+                  return `${duration}:00`
+                }
+                // If it's already in MM:SS format, return as is
+                if (/^\d+:\d{2}$/.test(duration)) {
+                  return duration
+                }
+                // Default fallback
+                return duration
+              }
+
               return (
                 <li
                   key={update._id}
@@ -157,7 +170,7 @@ const Articles = ({ articles, updates }: Props) => {
                   {update.title}
                   <span className="font-sm ml-2 flex items-center text-xs md:text-base">
                     {getIcon(update.type)}
-                    {update.duration}
+                    {formatDuration(update.duration)}
                   </span>
                 </li>
               )

--- a/sanity-vaasamosquecms/schemas/documents/update.js
+++ b/sanity-vaasamosquecms/schemas/documents/update.js
@@ -26,7 +26,7 @@ export default {
       name: 'duration',
       title: 'Duration',
       type: 'string',
-      description: 'Duration in format MM:SS (e.g., 10:24)',
+      description: 'Duration in format MM:SS (e.g., 10:24) or just minutes (e.g., 10)',
       validation: (Rule) => Rule.required(),
     },
     {


### PR DESCRIPTION
…ed a formatDuration function to standardize duration display, allowing for both MM:SS and minute-only formats. Updated schema description to reflect this change.